### PR TITLE
Adds a 1.25s delay between players for specifically the entrance clip

### DIFF
--- a/NASB Voice Mod/Controllers/VoiceController.cs
+++ b/NASB Voice Mod/Controllers/VoiceController.cs
@@ -11,15 +11,18 @@ namespace VoiceMod.Controllers
     class VoiceController : MonoBehaviour
     {
         private string agentId;
+        private GameAgent agent;
         private GameAgentStateMachine stateMachine;
         private Voicepack voicepack;
         private readonly Dictionary<int, string> lookup = new Dictionary<int, string>();
+        private Dictionary<string, int> stateIdDict;
 
         void Start()
         {
-            agentId = GetComponent<GameAgent>()?.GameUniqueIdentifier;
+            agent = GetComponent<GameAgent>();
+            agentId = agent?.GameUniqueIdentifier;
             stateMachine = GetComponent<GameAgentStateMachine>();
-            var stateIdDict = stateMachine.GetPrivateField<Dictionary<string, int>>("stateIdDict");
+            stateIdDict = stateMachine.GetPrivateField<Dictionary<string, int>>("stateIdDict");
 
             if (agentId == null ||
                 stateMachine == null ||
@@ -64,10 +67,20 @@ namespace VoiceMod.Controllers
             {
                 if (lookup.TryGetValue(stateMachine.CurrentStateId, out var id))
                 {
-                    voicepack.Play(id);
+                    int entryId = stateIdDict["entrance"];
+                    if (stateMachine.CurrentStateId == entryId)
+                        Invoke("PlayEntranceAudio", agent.playerIndex * 1.25f);
+                    else voicepack.Play(id);
                 }
             }
             stateLastFrame = stateMachine.CurrentStateId;
+        }
+
+        private void PlayEntranceAudio()
+        {
+            //All the checking and tryGets were done already. We _know_ this exists or the code wouldn't have gotten this far
+            string id = lookup[stateIdDict["entrance"]];
+            voicepack.Play(id);
         }
     }
 }


### PR DESCRIPTION
Whenever the entrance clip is loaded, adds in a delay equal to 1.25s times the player's index. Experimentation has found this to be a fairly decent amount to get enough delay between clips without bleeding into the fight much.